### PR TITLE
Version 1.0.5

### DIFF
--- a/CentCom.API/CentCom.API.csproj
+++ b/CentCom.API/CentCom.API.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <Version>1.0.4</Version>
-    <AssemblyVersion>1.0.4.0</AssemblyVersion>
+    <Version>1.0.5</Version>
+    <AssemblyVersion>1.0.5.0</AssemblyVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/CentCom.Common/CentCom.Common.csproj
+++ b/CentCom.Common/CentCom.Common.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <Version>1.0.5</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/CentCom.Common/Data/DatabaseContext.cs
+++ b/CentCom.Common/Data/DatabaseContext.cs
@@ -2,6 +2,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.Extensions.Configuration;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -30,7 +31,8 @@ namespace CentCom.Common.Data
                 entity.Property(e => e.Id).UseIdentityAlwaysColumn();
                 entity.Property(e => e.CKey).IsRequired().HasMaxLength(32);
                 entity.Property(e => e.Source).IsRequired();
-                entity.Property(e => e.BannedOn).IsRequired();
+                entity.Property(e => e.BannedOn).IsRequired().HasConversion(v => v, v => DateTime.SpecifyKind(v, DateTimeKind.Utc));
+                entity.Property(e => e.Expires).HasConversion(v => v, v => v.HasValue ? DateTime.SpecifyKind(v.Value, DateTimeKind.Utc) : (DateTime?)null);
                 entity.Property(e => e.BannedBy).IsRequired().HasMaxLength(32);
                 entity.Property(e => e.UnbannedBy).HasMaxLength(32);
                 entity.Property(e => e.BanType).IsRequired();
@@ -61,7 +63,7 @@ namespace CentCom.Common.Data
                 entity.HasKey(e => e.Id);
                 entity.Property(e => e.Id).UseIdentityAlwaysColumn();
                 entity.Property(e => e.Name).IsRequired();
-                entity.Property(e => e.PerformedAt).IsRequired();
+                entity.Property(e => e.PerformedAt).IsRequired().HasConversion(v => v, v => DateTime.SpecifyKind(v, DateTimeKind.Utc));
                 entity.Property(e => e.Version).IsRequired();
                 entity.HasIndex(e => new { e.Name, e.Version }).IsUnique();
             });

--- a/CentCom.Common/Extensions/JsonIPAddressConverter.cs
+++ b/CentCom.Common/Extensions/JsonIPAddressConverter.cs
@@ -1,0 +1,29 @@
+﻿using System.Net;
+
+namespace System.Text.Json.Serialization
+{
+	/// From https://github.com/Macross-Software/core
+	public class JsonIPAddressConverter : JsonConverter<IPAddress>
+	{
+		/// <inheritdoc/>
+		public override IPAddress Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType != JsonTokenType.String)
+				throw new JsonException();
+
+			try
+			{
+				return IPAddress.Parse(reader.GetString());
+			}
+			catch (Exception ex)
+			{
+				throw new JsonException("Unexpected value format, unable to parse IPAddress.", ex);
+			}
+		}
+
+        public override void Write(Utf8JsonWriter writer, IPAddress value, JsonSerializerOptions options)
+        {
+			writer.WriteStringValue(value.ToString());
+        }
+    }
+}

--- a/CentCom.Common/Models/Ban.cs
+++ b/CentCom.Common/Models/Ban.cs
@@ -1,9 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Configuration;
 using System.Linq;
 using System.Net;
+using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
 
 namespace CentCom.Common.Models
@@ -14,6 +13,7 @@ namespace CentCom.Common.Models
 
         public int Id { get; set; }
         public int Source { get; set; }
+        [JsonIgnore]
         public virtual BanSource SourceNavigation { get; set; }
         public BanType BanType { get; set; }
         public string CKey { get; set; }
@@ -22,6 +22,7 @@ namespace CentCom.Common.Models
         public string Reason { get; set; }
         public DateTime? Expires { get; set; }
         public string UnbannedBy { get; set; }
+        [JsonConverter(typeof(JsonIPAddressConverter))]
         public IPAddress IP { get; set; }
         public long? CID { get; set; }
         public string BanID { get; set; }
@@ -54,7 +55,7 @@ namespace CentCom.Common.Models
                     && Reason == other.Reason
                     && Expires == other.Expires
                     && UnbannedBy == other.UnbannedBy
-                    && IP == other.IP
+                    && (IP == null || IP.Equals(other.IP))
                     && CID == other.CID
                     && (BanType == BanType.Server
                             || (JobBans != null && other.JobBans != null && JobBans.SetEquals(other.JobBans)));
@@ -107,9 +108,10 @@ namespace CentCom.Common.Models
             return hash.ToHashCode();
         }
 
-        public void MakeKeyCanonical()
+        public void MakeKeysCanonical()
         {
             CKey = CKey == null ? null : GetCanonicalKey(CKey);
+            BannedBy = BannedBy == null ? null : GetCanonicalKey(BannedBy);
         }
 
         public static string GetCanonicalKey(string raw)

--- a/CentCom.Common/Models/Ban.cs
+++ b/CentCom.Common/Models/Ban.cs
@@ -112,6 +112,7 @@ namespace CentCom.Common.Models
         {
             CKey = CKey == null ? null : GetCanonicalKey(CKey);
             BannedBy = BannedBy == null ? null : GetCanonicalKey(BannedBy);
+            UnbannedBy = UnbannedBy == null ? null : GetCanonicalKey(UnbannedBy);
         }
 
         public static string GetCanonicalKey(string raw)

--- a/CentCom.Common/Models/Ban.cs
+++ b/CentCom.Common/Models/Ban.cs
@@ -46,7 +46,6 @@ namespace CentCom.Common.Models
             }
             else
             {
-                var otherJobs = other.JobBans?.Select(x => x.Job).ToImmutableHashSet();
                 return Source == other.Source
                     && BannedOn == other.BannedOn
                     && BanType == other.BanType
@@ -57,8 +56,8 @@ namespace CentCom.Common.Models
                     && UnbannedBy == other.UnbannedBy
                     && IP == other.IP
                     && CID == other.CID
-                    && (((JobBans == null || JobBans.Count == 0) && other.JobBans == null)
-                            || (JobBans != null && other.JobBans != null && JobBans.Select(y => y.Job).ToImmutableHashSet().SetEquals(otherJobs)));
+                    && (BanType == BanType.Server
+                            || (JobBans != null && other.JobBans != null && JobBans.SetEquals(other.JobBans)));
             }
         }
 

--- a/CentCom.Common/Models/Ban.cs
+++ b/CentCom.Common/Models/Ban.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Configuration;
+using System.Linq;
 using System.Net;
 using System.Text.RegularExpressions;
 
 namespace CentCom.Common.Models
 {
-    public class Ban
+    public class Ban :IEquatable<Ban>
     {
         private static Regex _keyReplacePattern = new Regex(@"[^a-z0-9]");
 
@@ -22,11 +25,102 @@ namespace CentCom.Common.Models
         public IPAddress IP { get; set; }
         public long? CID { get; set; }
         public string BanID { get; set; }
-        public List<JobBan> JobBans { get; set; }
+        public HashSet<JobBan> JobBans { get; set; }
+
+        /// <summary>
+        /// Determines if two bans are equal, using their values
+        /// </summary>
+        /// <param name="other">The ban to compare against</param>
+        /// <returns>If the two bans are equal by their values</returns>
+        /// <remarks>
+        /// Note that these equals are really just used for determining if
+        /// the contents of two bans are the same, at which point they're equal.
+        /// </remarks>
+        public bool Equals(Ban other)
+        {
+            if (other == null) return false;
+            else if (BanID != null || other.BanID != null)
+            {
+                return Source == other.Source
+                    && BanID == other.BanID;
+            }
+            else
+            {
+                var otherJobs = other.JobBans?.Select(x => x.Job).ToImmutableHashSet();
+                return Source == other.Source
+                    && BannedOn == other.BannedOn
+                    && BanType == other.BanType
+                    && CKey == other.CKey
+                    && BannedBy == other.BannedBy
+                    && Reason == other.Reason
+                    && Expires == other.Expires
+                    && UnbannedBy == other.UnbannedBy
+                    && IP == other.IP
+                    && CID == other.CID
+                    && (((JobBans == null || JobBans.Count == 0) && other.JobBans == null)
+                            || (JobBans != null && other.JobBans != null && JobBans.Select(y => y.Job).ToImmutableHashSet().SetEquals(otherJobs)));
+            }
+        }
+
+        public static bool operator ==(Ban a, Ban b)
+        {
+            return (a is null && b is null) || a.Equals(b);
+        }
+
+        public static bool operator !=(Ban a, Ban b)
+        {
+            return !(a == b);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return (obj is Ban ban) && Equals(ban);
+        }
+
+        public override int GetHashCode()
+        {
+            var hash = new HashCode();
+            if (BanID != null)
+            {
+                hash.Add(BanID);
+                hash.Add(Source);
+            }
+            else
+            {
+                hash.Add(Source);
+                hash.Add(BannedOn);
+                hash.Add(BanType);
+                hash.Add(CKey);
+                hash.Add(BannedBy);
+                hash.Add(Reason);
+                hash.Add(Expires);
+                hash.Add(UnbannedBy);
+                hash.Add(IP);
+                hash.Add(CID);
+                if (JobBans != null)
+                {
+                    foreach (var job in JobBans.OrderBy(x => x.Job))
+                    {
+                        hash.Add(job.Job, StringComparer.OrdinalIgnoreCase);
+                    }
+                }
+            }
+            return hash.ToHashCode();
+        }
 
         public void MakeKeyCanonical()
         {
-            CKey = CKey == null ? null : _keyReplacePattern.Replace(CKey.ToLower(), "");
+            CKey = CKey == null ? null : GetCanonicalKey(CKey);
+        }
+
+        public static string GetCanonicalKey(string raw)
+        {
+            if (raw == null)
+            {
+                throw new ArgumentNullException(nameof(raw));
+            }
+
+            return _keyReplacePattern.Replace(raw.ToLower(), "");
         }
     }
 }

--- a/CentCom.Common/Models/JobBan.cs
+++ b/CentCom.Common/Models/JobBan.cs
@@ -1,16 +1,18 @@
 ﻿using System;
+using System.Text.Json.Serialization;
 
 namespace CentCom.Common.Models
 {
     public class JobBan : IEquatable<JobBan>
     {
         public int BanId { get; set; }
+        [JsonIgnore]
         public virtual Ban BanNavigation { get; set; }
         public string Job { get; set; }
 
         public bool Equals(JobBan other)
         {
-            return !(other is null) && BanId == other.BanId && Job == other.Job;
+            return !(other is null) && Job == other.Job;
         }
 
         public static bool operator ==(JobBan a, JobBan b) 
@@ -31,7 +33,6 @@ namespace CentCom.Common.Models
         public override int GetHashCode()
         {
             var hash = new HashCode();
-            hash.Add(BanId);
             hash.Add(Job, StringComparer.OrdinalIgnoreCase);
             return hash.ToHashCode();
         }

--- a/CentCom.Common/Models/JobBan.cs
+++ b/CentCom.Common/Models/JobBan.cs
@@ -1,9 +1,39 @@
-﻿namespace CentCom.Common.Models
+﻿using System;
+
+namespace CentCom.Common.Models
 {
-    public class JobBan
+    public class JobBan : IEquatable<JobBan>
     {
         public int BanId { get; set; }
         public virtual Ban BanNavigation { get; set; }
         public string Job { get; set; }
+
+        public bool Equals(JobBan other)
+        {
+            return !(other is null) && BanId == other.BanId && Job == other.Job;
+        }
+
+        public static bool operator ==(JobBan a, JobBan b) 
+        {
+            return (a is null && b is null) || a.Equals(b);
+        }
+
+        public static bool operator !=(JobBan a, JobBan b)
+        {
+            return !(a == b);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return (obj is JobBan jb) && Equals(jb);
+        }
+
+        public override int GetHashCode()
+        {
+            var hash = new HashCode();
+            hash.Add(BanId);
+            hash.Add(Job, StringComparer.OrdinalIgnoreCase);
+            return hash.ToHashCode();
+        }
     }
 }

--- a/CentCom.Server/BanSources/BanParser.cs
+++ b/CentCom.Server/BanSources/BanParser.cs
@@ -119,15 +119,14 @@ namespace CentCom.Server.BanSources
                 }
                 else
                 {
-                    var bJobs = b.JobBans?.Select(x => x.Job).ToHashSet();
                     matchedBan = storedBans.FirstOrDefault(x =>
                         x.SourceNavigation.Name == b.SourceNavigation.Name
                         && x.BannedOn == b.BannedOn
                         && x.BanType == b.BanType
                         && x.CKey == b.CKey
                         && x.BannedBy == b.BannedBy
-                        && (((x.JobBans == null || x.JobBans.Count == 0) && b.JobBans == null)
-                            || (x.JobBans != null && b.JobBans != null && x.JobBans.Select(y => y.Job).ToHashSet().SetEquals(bJobs))));
+                        && (x.BanType == BanType.Server 
+                            || (x.JobBans != null && b.JobBans != null && x.JobBans.SetEquals(b.JobBans))));
                 }
 
                 // Update ban if an existing one is found

--- a/CentCom.Server/BanSources/FulpBanParser.cs
+++ b/CentCom.Server/BanSources/FulpBanParser.cs
@@ -1,0 +1,66 @@
+﻿using CentCom.Common.Data;
+using CentCom.Common.Models;
+using CentCom.Server.Services;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CentCom.Server.BanSources
+{
+    public class FulpBanParser : BanParser
+    {
+        public override Dictionary<string, BanSource> Sources => new Dictionary<string, BanSource>()
+        {
+            { "fulp", new BanSource()
+            {
+                Display = "FulpStation",
+                Name = "fulp",
+                RoleplayLevel = RoleplayLevel.Low
+            } }
+        };
+        private FulpBanService _banService;
+        private const int PAGES_PER_BATCH = 12;
+
+        public FulpBanParser(DatabaseContext dbContext, FulpBanService banService, ILogger<FulpBanParser> logger) : base(dbContext, logger)
+        {
+            _banService = banService;
+            _logger = logger;
+        }
+
+        public override async Task<IEnumerable<Ban>> FetchAllBansAsync()
+        {
+            _logger.LogInformation("Getting all bans for FulpStation...");
+            return await _banService.GetBansBatchedAsync();
+        }
+
+        public override async Task<IEnumerable<Ban>> FetchNewBansAsync()
+        {
+            _logger.LogInformation("Getting new bans for FulpStation...");
+            var recent = await _dbContext.Bans
+                .Where(x => Sources.Keys.Contains(x.SourceNavigation.Name))
+                .OrderByDescending(x => x.BannedOn)
+                .Take(5)
+                .Include(x => x.JobBans)
+                .Include(x => x.SourceNavigation)
+                .ToListAsync();
+            var foundBans = new List<Ban>();
+            var page = 1;
+
+            while (true)
+            {
+                var batch = await _banService.GetBansBatchedAsync(page, PAGES_PER_BATCH);
+                foundBans.AddRange(batch);
+                if (batch.Count() == 0 || batch.Any(x => recent.Any(y => y.BannedOn == x.BannedOn && y.CKey == y.CKey)))
+                {
+                    break;
+                }
+            }
+
+            return foundBans;
+        }
+    }
+}

--- a/CentCom.Server/BanSources/FulpBanParser.cs
+++ b/CentCom.Server/BanSources/FulpBanParser.cs
@@ -17,7 +17,7 @@ namespace CentCom.Server.BanSources
         {
             { "fulp", new BanSource()
             {
-                Display = "FulpStation",
+                Display = "Fulpstation",
                 Name = "fulp",
                 RoleplayLevel = RoleplayLevel.Low
             } }
@@ -33,13 +33,13 @@ namespace CentCom.Server.BanSources
 
         public override async Task<IEnumerable<Ban>> FetchAllBansAsync()
         {
-            _logger.LogInformation("Getting all bans for FulpStation...");
+            _logger.LogInformation("Getting all bans for Fulpstation...");
             return await _banService.GetBansBatchedAsync();
         }
 
         public override async Task<IEnumerable<Ban>> FetchNewBansAsync()
         {
-            _logger.LogInformation("Getting new bans for FulpStation...");
+            _logger.LogInformation("Getting new bans for Fulpstation...");
             var recent = await _dbContext.Bans
                 .Where(x => Sources.Keys.Contains(x.SourceNavigation.Name))
                 .OrderByDescending(x => x.BannedOn)

--- a/CentCom.Server/BanSources/VgBanParser.cs
+++ b/CentCom.Server/BanSources/VgBanParser.cs
@@ -18,7 +18,6 @@ namespace CentCom.Server.BanSources
                 RoleplayLevel = RoleplayLevel.Low
             } }
         };
-        public override bool SourceSupportsBanIDs => false;
         private VgBanService _banService;
 
         public VgBanParser(DatabaseContext dbContext, VgBanService banService, ILogger<VgBanParser> logger) : base(dbContext, logger)

--- a/CentCom.Server/CentCom.Server.csproj
+++ b/CentCom.Server/CentCom.Server.csproj
@@ -1,11 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <AssemblyVersion>1.0.4.0</AssemblyVersion>
-    <FileVersion>1.0.4.0</FileVersion>
-    <Version>1.0.4</Version>
+    <AssemblyVersion>1.0.5.0</AssemblyVersion>
+    <FileVersion>1.0.5.0</FileVersion>
+    <Version>1.0.5</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/CentCom.Server/Program.cs
+++ b/CentCom.Server/Program.cs
@@ -156,6 +156,7 @@ namespace CentCom.Server
             services.AddSingleton<BeeBanService>();
             services.AddSingleton<VgBanService>();
             services.AddSingleton<YogBanService>();
+            services.AddSingleton<FulpBanService>();
 
             // Add ban parsers
             var parsers = AppDomain.CurrentDomain.GetAssemblies().Aggregate(new List<Type>(), (curr, next) =>

--- a/CentCom.Server/Services/BeeBanService.cs
+++ b/CentCom.Server/Services/BeeBanService.cs
@@ -36,7 +36,7 @@ namespace CentCom.Server.Services
 
             if (response.StatusCode != System.Net.HttpStatusCode.OK)
             {
-                _logger.LogError("Beestation website returned a non-200 HTTP response code: {response.StatusCode}, aborting parse.");
+                _logger.LogError($"Beestation website returned a non-200 HTTP response code: {response.StatusCode}, aborting parse.");
                 throw new BanSourceUnavailableException($"Beestation website returned a non-200 HTTP response code: {response.StatusCode}, aborting parse.");
             }
 
@@ -59,9 +59,9 @@ namespace CentCom.Server.Services
                 if (toAdd.BanType == BanType.Job)
                 {
                     toAdd.JobBans = b["job"].EnumerateArray()
-                        .Select(x => x.GetString()).ToHashSet()
+                        .Select(x => x.GetString().ToLower())
                         .Select(x => new JobBan() { Job = x })
-                        .ToList();
+                        .ToHashSet();
                 }
 
                 toReturn.Add(toAdd);

--- a/CentCom.Server/Services/FulpBanService.cs
+++ b/CentCom.Server/Services/FulpBanService.cs
@@ -1,0 +1,106 @@
+﻿using CentCom.Common.Models;
+using CentCom.Server.Exceptions;
+using Extensions;
+using Microsoft.Extensions.Logging;
+using RestSharp;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace CentCom.Server.Services
+{
+    public class FulpBanService
+    {
+        private IRestClient _client;
+        ILogger _logger;
+        private const string BASE_URL = "https://api.fulp.gg/";
+        private const int RECORDS_PER_PAGE = 50;
+        private static BanSource _banSource = new BanSource() { Name = "fulp" };
+        
+
+        public FulpBanService(ILogger<FulpBanService> logger)
+        {
+            _logger = logger;
+            _client = new RestClient(BASE_URL);
+        }
+
+        public async Task<IEnumerable<Ban>> GetBansAsync(int page = 1)
+        {
+            var request = new RestRequest($"bans/{RECORDS_PER_PAGE}/{page}", Method.GET, DataFormat.Json);
+            var response = await _client.ExecuteAsync(request);
+
+            if (response.StatusCode != System.Net.HttpStatusCode.OK)
+            {
+                _logger.LogError($"Fulpstation website returned a non-200 HTTP response code: {response.StatusCode}, aborting parse.");
+                throw new BanSourceUnavailableException($"Fulpstation website returned a non-200 HTTP response code: {response.StatusCode}, aborting parse.");
+            }
+
+            var toReturn = new List<Ban>();
+            var content = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(response.Content);
+            foreach (var ban in content["value"].GetProperty("bans").EnumerateArray())
+            {
+                var toAdd = new Ban()
+                {
+                    BannedOn = DateTime.Parse(ban.GetProperty("banApplyTime").GetString()).ToUniversalTime(),
+                    BannedBy = ban.GetProperty("adminCkey").GetString(),
+                    BanType = ban.GetProperty("role")[0].GetString().ToLower() == "server" ? BanType.Server : BanType.Job,
+                    Expires = ban.GetProperty("banExpireTime").GetString() == null ? (DateTime?)null : DateTime.Parse(ban.GetProperty("banExpireTime").GetString()).ToUniversalTime(),
+                    CKey = ban.GetProperty("bannedCkey").GetString(),
+                    Reason = ban.GetProperty("reason").GetString(),
+                    SourceNavigation = _banSource
+                };
+
+                if (toAdd.BanType == BanType.Job)
+                {
+                    toAdd.JobBans = ban.GetProperty("role").EnumerateArray()
+                        .Select(x => x.GetString().ToLower())
+                        .Select(x => new JobBan() { Job = x })
+                        .ToHashSet();
+                }
+
+                toReturn.Add(toAdd);
+            }
+
+            return toReturn;
+        }
+
+        public async Task<IEnumerable<Ban>> GetBansBatchedAsync(int startPage = 1, int pages = -1)
+        {
+            var maxPages = await GetNumberOfPagesAsync();
+            var range = Enumerable.Range(startPage, pages != -1 ? Math.Min(startPage + pages, maxPages) : maxPages);
+            var toReturn = new ConcurrentBag<Ban>();
+            await range.AsyncParallelForEach(async page =>
+            {
+                foreach (var b in await GetBansAsync(page))
+                {
+                    toReturn.Add(b);
+                }
+            }, 6);
+            return toReturn;
+        }
+
+        public async Task<int> GetNumberOfPagesAsync()
+        {
+            var request = new RestRequest($"bans/{RECORDS_PER_PAGE}/1", Method.GET, DataFormat.Json);
+            var result = await _client.ExecuteAsync(request);
+
+            if (result.StatusCode != System.Net.HttpStatusCode.OK)
+            {
+                throw new Exception($"Unexpected non-200 status code [{result.StatusCode}] when trying to retrieve number of ban pages for Fulpstation");
+            }
+
+            var content = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(result.Content);
+            if (content["value"].TryGetProperty("lastPage", out var lastpage))
+            {
+                return lastpage.GetInt32();
+            }
+            else
+            {
+                throw new Exception("Failed to find the last page number in the response from Fulpstation's API");
+            }
+        }
+    }
+}

--- a/CentCom.Server/Services/VgBanService.cs
+++ b/CentCom.Server/Services/VgBanService.cs
@@ -102,7 +102,7 @@ namespace CentCom.Server.Services
                 {
                     CKey = ckey,
                     BanType = BanType.Job,
-                    JobBans = jobs.Select(x => x.ToLower()).ToHashSet().Select(x => new JobBan() { Job = x }).ToList(),
+                    JobBans = jobs.Select(x => x.ToLower()).Select(x => new JobBan() { Job = x }).ToHashSet(),
                     Reason = reason,
                     BannedBy = bannedBy,
                     BannedOn = date.UtcDateTime,

--- a/CentCom.Test/Ban_EqualsShould.cs
+++ b/CentCom.Test/Ban_EqualsShould.cs
@@ -1,7 +1,7 @@
 ﻿using CentCom.Common.Models;
 using System;
 using System.Collections.Generic;
-using System.Text;
+using System.Net;
 using Xunit;
 
 namespace CentCom.Test
@@ -177,6 +177,60 @@ namespace CentCom.Test
 
             Assert.True(banA == banB, "Two bans with the same jobbans in different orders should be equal");
             Assert.True(banA.GetHashCode() == banB.GetHashCode(), "Two bans with the same jobbans in different orders should be equal");
+        }
+
+        [Fact]
+        public void Equals_SameBanNullVsEmptyJobBans_ReturnTrue()
+        {
+            var banA = new Ban()
+            {
+                Id = 0,
+                Source = 15,
+                BanType = BanType.Server,
+                JobBans = null
+            };
+
+            var banB = new Ban()
+            {
+                Id = 0,
+                Source = 15,
+                BanType = BanType.Server,
+                JobBans = new HashSet<JobBan>()
+            };
+
+            Assert.True(banA == banB, "Bans should be equal if the jobbans only differ by null and an empty set");
+            Assert.True(banA.GetHashCode() == banB.GetHashCode(), "Bans should have the same hashcode if the jobbans only differ by null and an empty set");
+        }
+
+        [Fact]
+        public void Equals_SameBansSameIP_ReturnsTrue()
+        {
+            var banA = new Ban()
+            {
+                Id = 193912,
+                Source = 84,
+                BanType = BanType.Server,
+                CKey = "kinler101",
+                BannedOn = DateTime.Parse("2020-08-03T22:23:58Z"),
+                BannedBy = "archsunder",
+                Reason = "testing reason",
+                IP = IPAddress.Parse("108.20.220.45")
+            };
+
+            var banB = new Ban()
+            {
+                Id = 0,
+                Source = 84,
+                BanType = BanType.Server,
+                CKey = "kinler101",
+                BannedOn = DateTime.Parse("2020-08-03T22:23:58Z"),
+                BannedBy = "archsunder",
+                Reason = "testing reason",
+                IP = IPAddress.Parse("108.20.220.45")
+            };
+
+            Assert.True(banA == banB, "Bans should be equal if all values are equal, including IP");
+            Assert.True(banA.GetHashCode() == banB.GetHashCode(), "Bans should have the same hashcode if all values are equal, including IP");
         }
     }
 }

--- a/CentCom.Test/Ban_EqualsShould.cs
+++ b/CentCom.Test/Ban_EqualsShould.cs
@@ -1,0 +1,182 @@
+﻿using CentCom.Common.Models;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace CentCom.Test
+{
+    public class Ban_EqualsShould
+    {
+        [Fact]
+        public void Equals_SameBanDifferentID_ReturnTrue()
+        {
+            var source = new BanSource()
+            {
+                Display = "test source",
+                Name = "test",
+                RoleplayLevel = RoleplayLevel.Medium,
+                Id = 3
+            };
+
+            var banA = new Ban()
+            {
+                Id = 12,
+                CKey = "test",
+                BannedOn = DateTime.MinValue,
+                BannedBy = "tester",
+                BanType = BanType.Server,
+                Reason = "what a great test",
+                Source = source.Id,
+                SourceNavigation = source
+            };
+
+            var banB = new Ban()
+            {
+                Id = 0,
+                CKey = "test",
+                BannedOn = DateTime.MinValue,
+                BannedBy = "tester",
+                BanType = BanType.Server,
+                Reason = "what a great test",
+                Source = source.Id,
+                SourceNavigation = source
+            };
+
+            Assert.True(banA == banB, "Two bans equal by internal values should be equal");
+            Assert.True(banA.GetHashCode() == banB.GetHashCode(), "Two bans equal by internal values should have equal hashcodes");
+        }
+
+        [Fact]
+        public void Equals_SameBanDifferentIDDifferentSource_ReturnFalse()
+        {
+            var sourceA = new BanSource()
+            {
+                Display = "test source A",
+                Name = "testA",
+                RoleplayLevel = RoleplayLevel.Medium,
+                Id = 3
+            };
+
+            var sourceB = new BanSource()
+            {
+                Display = "test source B",
+                Name = "testB",
+                RoleplayLevel = RoleplayLevel.Medium,
+                Id = 4
+            };
+
+            var banA = new Ban()
+            {
+                Id = 12,
+                CKey = "test",
+                BannedOn = DateTime.MinValue,
+                BannedBy = "tester",
+                BanType = BanType.Server,
+                Reason = "what a great test",
+                Source = sourceA.Id,
+                SourceNavigation = sourceA
+            };
+
+            var banB = new Ban()
+            {
+                Id = 0,
+                CKey = "test",
+                BannedOn = DateTime.MinValue,
+                BannedBy = "tester",
+                BanType = BanType.Server,
+                Reason = "what a great test",
+                Source = sourceB.Id,
+                SourceNavigation = sourceB
+            };
+
+            Assert.False(banA == banB, "Two bans from different sources should not be equal by internal values");
+            Assert.False(banA.GetHashCode() == banB.GetHashCode(), "Two bans from different sources should not have equal hashcodes");
+        }
+
+        [Fact]
+        public void Equals_SameBanByBanID_ReturnTrue()
+        {
+            var banA = new Ban()
+            {
+                BanID = "epic",
+                CKey = "doesn't matter"
+            };
+
+            var banB = new Ban()
+            {
+                BanID = "epic",
+                CKey = "different"
+            };
+
+            Assert.True(banA == banB, "Two bans with BanIDs should be checked for equality by ID");
+            Assert.True(banA.GetHashCode() == banB.GetHashCode(), "Two bans with BanIDs that are equal should have equal hashcodes");
+        }
+
+        [Fact]
+        public void Equals_SameBanIDDifferentSource_ReturnFalse()
+        {
+            var sourceA = new BanSource()
+            {
+                Display = "test source A",
+                Name = "testA",
+                RoleplayLevel = RoleplayLevel.Medium,
+                Id = 3
+            };
+
+            var sourceB = new BanSource()
+            {
+                Display = "test source B",
+                Name = "testB",
+                RoleplayLevel = RoleplayLevel.Medium,
+                Id = 4
+            };
+
+            var banA = new Ban()
+            {
+                BanID = "epic",
+                CKey = "doesn't matter",
+                Source = sourceA.Id,
+                SourceNavigation = sourceA
+            };
+
+            var banB = new Ban()
+            {
+                BanID = "epic",
+                CKey = "different",
+                Source = sourceB.Id,
+                SourceNavigation = sourceB
+            };
+
+            Assert.False(banA == banB, "Two bans from different sources should not be equal by BanID");
+            Assert.False(banA.GetHashCode() == banB.GetHashCode(), "Two bans from different sources should not have equal hashcodes");
+        }
+
+        [Fact]
+        public void Equals_SameBanDifferentJobOrder_ReturnTrue()
+        {
+            var banA = new Ban()
+            {
+                Id = 12,
+                JobBans = new HashSet<JobBan>()
+                {
+                    new JobBan() { Job = "captain" },
+                    new JobBan() { Job = "assistant" }
+                }
+            };
+
+            var banB = new Ban()
+            {
+                Id = 0,
+                JobBans = new HashSet<JobBan>()
+                {
+                    new JobBan() { Job = "assistant" },
+                    new JobBan() { Job = "captain" }
+                }
+            };
+
+            Assert.True(banA == banB, "Two bans with the same jobbans in different orders should be equal");
+            Assert.True(banA.GetHashCode() == banB.GetHashCode(), "Two bans with the same jobbans in different orders should be equal");
+        }
+    }
+}

--- a/CentCom.Test/Ban_GetCanonicalKeyShould.cs
+++ b/CentCom.Test/Ban_GetCanonicalKeyShould.cs
@@ -1,7 +1,5 @@
 ﻿using CentCom.Common.Models;
 using System;
-using System.Collections.Generic;
-using System.Text;
 using Xunit;
 
 namespace CentCom.Test

--- a/CentCom.Test/Ban_GetCanonicalKeyShould.cs
+++ b/CentCom.Test/Ban_GetCanonicalKeyShould.cs
@@ -1,0 +1,24 @@
+﻿using CentCom.Common.Models;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace CentCom.Test
+{
+    public class Ban_GetCanonicalKeyShould
+    {
+        [Fact]
+        public void GetCanonicalKey_FromRaw_ReturnTrue()
+        {
+            var rawKey = "B o bbahbrown";
+            Assert.True("bobbahbrown" == Ban.GetCanonicalKey(rawKey));
+        }
+
+        [Fact]
+        public void GetCanonicalKey_NullArgument_ThrowsException()
+        {
+            Assert.Throws<ArgumentNullException>(() => Ban.GetCanonicalKey(null));
+        }
+    }
+}

--- a/CentCom.Test/CentCom.Test.csproj
+++ b/CentCom.Test/CentCom.Test.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="1.3.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\CentCom.Common\CentCom.Common.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/CentCom.Test/JobBan_EqualsShould.cs
+++ b/CentCom.Test/JobBan_EqualsShould.cs
@@ -1,0 +1,51 @@
+﻿using CentCom.Common.Models;
+using Xunit;
+
+namespace CentCom.Test
+{
+    public class JobBan_EqualsShould
+    {
+        [Fact]
+        public void Equals_SameJobBan_ReturnTrue()
+        {
+            var jobA = new JobBan()
+            {
+                BanId = 18922,
+                Job = "ooc"
+            };
+
+            var jobB = new JobBan()
+            {
+                BanId = 18922,
+                Job = "ooc"
+            };
+
+            Assert.True(jobA == jobB, "Two jobs equal by internal values should be equal");
+            Assert.True(jobA.GetHashCode() == jobB.GetHashCode(), "Two jobs equal by internal values should have the same hashcode");
+        }
+
+        /// <summary>
+        /// This test is important for comparing bans in the database versus
+        /// bans that have been parsed, we shouldn't consider ban id for
+        /// job ban equality as semantically it would never be practiced.
+        /// </summary>
+        [Fact]
+        public void Equals_SameJobBan_DifferentID_ReturnTrue()
+        {
+            var jobA = new JobBan()
+            {
+                BanId = 18922,
+                Job = "ooc"
+            };
+
+            var jobB = new JobBan()
+            {
+                BanId = 0,
+                Job = "ooc"
+            };
+
+            Assert.True(jobA == jobB, "Two jobs equal by job, even with differing IDs, should be equal");
+            Assert.True(jobA.GetHashCode() == jobB.GetHashCode(), "Two jobs equal by job, even with differing ids, should have the same hashcode");
+        }
+    }
+}

--- a/CentCom.sln
+++ b/CentCom.sln
@@ -3,11 +3,13 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.30320.27
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CentCom.Server", "CentCom.Server\CentCom.Server.csproj", "{E8742DF1-2BDF-42B6-9E3A-DB4074466ADA}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CentCom.Server", "CentCom.Server\CentCom.Server.csproj", "{E8742DF1-2BDF-42B6-9E3A-DB4074466ADA}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CentCom.API", "CentCom.API\CentCom.API.csproj", "{68FB58E4-9945-4B1E-9767-E3B1590F3CC4}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CentCom.API", "CentCom.API\CentCom.API.csproj", "{68FB58E4-9945-4B1E-9767-E3B1590F3CC4}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CentCom.Common", "CentCom.Common\CentCom.Common.csproj", "{1908B013-99C9-499C-ABA1-BC249CBDE3ED}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CentCom.Common", "CentCom.Common\CentCom.Common.csproj", "{1908B013-99C9-499C-ABA1-BC249CBDE3ED}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CentCom.Test", "CentCom.Test\CentCom.Test.csproj", "{B4A8FED4-ED2C-471B-9F07-A72B0E80E089}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -27,6 +29,10 @@ Global
 		{1908B013-99C9-499C-ABA1-BC249CBDE3ED}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1908B013-99C9-499C-ABA1-BC249CBDE3ED}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1908B013-99C9-499C-ABA1-BC249CBDE3ED}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B4A8FED4-ED2C-471B-9F07-A72B0E80E089}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B4A8FED4-ED2C-471B-9F07-A72B0E80E089}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B4A8FED4-ED2C-471B-9F07-A72B0E80E089}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B4A8FED4-ED2C-471B-9F07-A72B0E80E089}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Changelog:
- Added Fulp ban parsing (Closes #9)
- Added unit tests for bans, job bans, and ckey parsing
- Ensured ckeys were properly parsed for all three possible locations in Ban objects
- Fixed bug with comparing JobBan objects (Closes #8)
- Fixed bug with comparing Ban objects with JobBans (Closes #8)
- Fixed bug with comparing Ban objects with IPAddresses (Closes #8)
- Ensured all timestamps being sent to DB are stored as UTC
- Version bump to v1.0.5
- Fixed JSON encoding for JobBan, Ban, and BanSource objects