### PR TITLE
Alters the logic for the onlyActive query

### DIFF
--- a/CentCom.API/Services/Implemented/BanService.cs
+++ b/CentCom.API/Services/Implemented/BanService.cs
@@ -40,7 +40,7 @@ namespace CentCom.API.Services.Implemented
             }
             if (onlyActive)
             {
-                query = query.Where(x => x.UnbannedBy != null && (x.Expires == null || x.Expires > DateTime.UtcNow));
+                query = query.Where(x => x.UnbannedBy == null && (x.Expires == null || x.Expires > DateTime.UtcNow));
             }
             return await query.OrderByDescending(x => x.BannedOn)
                 .Select(x => BanData.FromBan(x))
@@ -55,7 +55,7 @@ namespace CentCom.API.Services.Implemented
                 .Where(x => x.Source == source);
             if (onlyActive)
             {
-                query = query.Where(x => x.UnbannedBy != null && (x.Expires == null || x.Expires > DateTime.UtcNow));
+                query = query.Where(x => x.UnbannedBy == null && (x.Expires == null || x.Expires > DateTime.UtcNow));
             }
             return await query.OrderByDescending(x => x.BannedOn)
                 .Select(x => BanData.FromBan(x))


### PR DESCRIPTION
Fixes #14 

The old logic had it checking to see if there was a value for `UnbannedBy` when it really should be checking to make sure that the value is null/unset.

Old results: 

![image](https://user-images.githubusercontent.com/26130695/90332909-96fd0f00-df86-11ea-9f41-902e72e8b992.png)

With the changes:

![image](https://user-images.githubusercontent.com/26130695/90333017-bea0a700-df87-11ea-8907-e576bfb501e8.png)

