### PR TITLE
Version 1.3.5 - Beestation deduplication

### DIFF
--- a/CentCom.API/CentCom.API.csproj
+++ b/CentCom.API/CentCom.API.csproj
@@ -2,9 +2,9 @@
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
-    <Version>1.3.4</Version>
-    <AssemblyVersion>1.3.4.0</AssemblyVersion>
-    <FileVersion>1.3.4.0</FileVersion>
+    <Version>1.3.5</Version>
+    <AssemblyVersion>1.3.5.0</AssemblyVersion>
+    <FileVersion>1.3.5.0</FileVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/CentCom.Common/CentCom.Common.csproj
+++ b/CentCom.Common/CentCom.Common.csproj
@@ -2,9 +2,9 @@
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
-    <Version>1.3.4</Version>
-    <AssemblyVersion>1.3.4.0</AssemblyVersion>
-    <FileVersion>1.3.4.0</FileVersion>
+    <Version>1.3.5</Version>
+    <AssemblyVersion>1.3.5.0</AssemblyVersion>
+    <FileVersion>1.3.5.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/CentCom.Common/Extensions/BanExtensions.cs
+++ b/CentCom.Common/Extensions/BanExtensions.cs
@@ -2,7 +2,7 @@
 using CentCom.Common.Models;
 using System.Collections.Generic;
 
-namespace CentCom.Server.Extensions
+namespace CentCom.Common.Extensions
 {
     public static class BanExtensions
     {

--- a/CentCom.Common/Models/Equality/BanEqualityComparer.cs
+++ b/CentCom.Common/Models/Equality/BanEqualityComparer.cs
@@ -43,11 +43,9 @@ namespace CentCom.Common.Models.Equality
             if (obj.BanID != null)
             {
                 hash.Add(obj.BanID);
-                hash.Add(obj.Source);
             }
             else
             {
-                hash.Add(obj.Source);
                 hash.Add(obj.BannedOn);
                 hash.Add(obj.BanType);
                 hash.Add(obj.CKey);

--- a/CentCom.Server/CentCom.Server.csproj
+++ b/CentCom.Server/CentCom.Server.csproj
@@ -3,9 +3,9 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
-    <AssemblyVersion>1.3.4.0</AssemblyVersion>
-    <FileVersion>1.3.4.0</FileVersion>
-    <Version>1.3.4</Version>
+    <AssemblyVersion>1.3.5.0</AssemblyVersion>
+    <FileVersion>1.3.5.0</FileVersion>
+    <Version>1.3.5</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/CentCom.Server/Services/BeeBanService.cs
+++ b/CentCom.Server/Services/BeeBanService.cs
@@ -1,6 +1,6 @@
-﻿using CentCom.Common.Models;
+﻿using CentCom.Common.Extensions;
+using CentCom.Common.Models;
 using CentCom.Server.Exceptions;
-using CentCom.Server.Extensions;
 using Extensions;
 using Microsoft.Extensions.Logging;
 using RestSharp;
@@ -82,6 +82,7 @@ namespace CentCom.Server.Services
             var maxPages = await GetNumberOfPagesAsync();
             var range = Enumerable.Range(startpage, pages != -1 ? pages : maxPages + 8); // pad with 8 pages for safety
             var toReturn = new ConcurrentBag<Ban>();
+            
             await range.AsyncParallelForEach(async page =>
             {
                 foreach (var b in await GetBansAsync(page))

--- a/CentCom.Server/Services/FulpBanService.cs
+++ b/CentCom.Server/Services/FulpBanService.cs
@@ -1,6 +1,6 @@
-﻿using CentCom.Common.Models;
+﻿using CentCom.Common.Extensions;
+using CentCom.Common.Models;
 using CentCom.Server.Exceptions;
-using CentCom.Server.Extensions;
 using Extensions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;

--- a/CentCom.Server/Services/TGMCBanService.cs
+++ b/CentCom.Server/Services/TGMCBanService.cs
@@ -1,11 +1,10 @@
-﻿using CentCom.Common.Models;
+﻿using CentCom.Common.Extensions;
+using CentCom.Common.Models;
 using CentCom.Server.Exceptions;
-using CentCom.Server.Extensions;
 using Extensions;
 using Microsoft.Extensions.Logging;
 using RestSharp;
 using System;
-using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
@@ -98,7 +97,7 @@ namespace CentCom.Server.Services
             }
 
             // Group jobbans
-            foreach (var group in dirtyBans.GroupBy(x => new { x.BannedOn, x.CKey, x.Reason }))
+            foreach (var group in dirtyBans.GroupBy(x => new { x.CKey, x.BannedOn }))
             {
                 var firstBan = group.OrderBy(x => x.BanID).First();
                 firstBan.AddJobRange(group.SelectMany(x => x.JobBans).Select(x => x.Job));
@@ -127,7 +126,7 @@ namespace CentCom.Server.Services
 
             // We have to ensure that our jobs are correctly grouped due to possible errors with paging
             var cleanBans = new List<Ban>(dirtyBans.Where(x => x.BanType == BanType.Server));
-            foreach (var group in dirtyBans.Where(x => x.BanType == BanType.Job).GroupBy(x => new { x.BannedOn, x.CKey, x.Reason }))
+            foreach (var group in dirtyBans.Where(x => x.BanType == BanType.Job).GroupBy(x => new { x.CKey, x.BannedOn }))
             {
                 var firstBan = group.OrderBy(x => x.BanID).First();
                 firstBan.AddJobRange(group.SelectMany(x => x.JobBans).Select(x => x.Job));

--- a/CentCom.Server/Services/VgBanService.cs
+++ b/CentCom.Server/Services/VgBanService.cs
@@ -1,7 +1,7 @@
 ﻿using AngleSharp;
+using CentCom.Common.Extensions;
 using CentCom.Common.Models;
 using CentCom.Server.Exceptions;
-using CentCom.Server.Extensions;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;

--- a/CentCom.Server/Services/YogBanService.cs
+++ b/CentCom.Server/Services/YogBanService.cs
@@ -1,6 +1,6 @@
-﻿using CentCom.Common.Models;
+﻿using CentCom.Common.Extensions;
+using CentCom.Common.Models;
 using CentCom.Server.Exceptions;
-using CentCom.Server.Extensions;
 using Microsoft.Extensions.Logging;
 using RestSharp;
 using System;

--- a/CentCom.Test/Ban_EqualsShould.cs
+++ b/CentCom.Test/Ban_EqualsShould.cs
@@ -1,6 +1,6 @@
-﻿using CentCom.Common.Models;
+﻿using CentCom.Common.Extensions;
+using CentCom.Common.Models;
 using CentCom.Common.Models.Equality;
-using CentCom.Server.Extensions;
 using System;
 using Xunit;
 


### PR DESCRIPTION
Changelog:
- Improved hash generation for Ban hashes
- Added de-duplication of bans from source data, this is to resolve the issue of Beestation's API returning over 1 million duplicated bans
- Added de-duplication of bans within the database during complete refresh stage