### PR TITLE
Version 1.3.10.1 - Bot Build Hotfix

### DIFF
--- a/CentCom.API/CentCom.API.csproj
+++ b/CentCom.API/CentCom.API.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
-    <Version>1.3.10</Version>
+    <Version>1.3.10.1</Version>
     <UserSecretsId>1f5f48fa-862f-4472-ba34-2c5a26035e88</UserSecretsId>
   </PropertyGroup>
 

--- a/CentCom.Bot/CentCom.Bot.csproj
+++ b/CentCom.Bot/CentCom.Bot.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <Version>1.3.10</Version>
+        <Version>1.3.10.1</Version>
         <TargetFramework>net5.0</TargetFramework>
         <UserSecretsId>c8af1449-8cdf-4707-a66d-51e896551bfb</UserSecretsId>
     </PropertyGroup>
@@ -13,6 +13,7 @@
         <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="5.0.0" />
         <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="5.0.0" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
         <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="5.0.0" />
         <PackageReference Include="Quartz" Version="3.3.3" />
         <PackageReference Include="Quartz.Extensions.DependencyInjection" Version="3.3.3" />
@@ -34,12 +35,6 @@
 
     <ItemGroup>
         <ProjectReference Include="..\CentCom.Common\CentCom.Common.csproj" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <Reference Include="Microsoft.Extensions.Hosting, Version=5.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60">
-        <HintPath>..\..\..\..\..\Program Files\dotnet\shared\Microsoft.AspNetCore.App\5.0.7\Microsoft.Extensions.Hosting.dll</HintPath>
-      </Reference>
     </ItemGroup>
 
 </Project>

--- a/CentCom.Bot/Program.cs
+++ b/CentCom.Bot/Program.cs
@@ -11,7 +11,6 @@ using CentCom.Common.Configuration;
 using CentCom.Common.Data;
 using Quartz;
 using Serilog;
-using Serilog.Filters;
 
 namespace CentCom.Bot
 {

--- a/CentCom.Common/CentCom.Common.csproj
+++ b/CentCom.Common/CentCom.Common.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
-    <Version>1.3.10</Version>
+    <Version>1.3.10.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/CentCom.Server/CentCom.Server.csproj
+++ b/CentCom.Server/CentCom.Server.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFramework>net5.0</TargetFramework>
-        <Version>1.3.10</Version>
+        <Version>1.3.10.1</Version>
         <UserSecretsId>94572412-7eb8-4652-aff2-8afc154cf139</UserSecretsId>
     </PropertyGroup>
 


### PR DESCRIPTION
Changelog:
- Fixed an issue wherein CentCom.Bot would fail to run on any host due to bad references.