### PR TITLE
Version 1.3.15 - Add AuStation, Resolve Issue with Null Ckey Bans & Standardized Ban Parsers

### DIFF
--- a/.idea/.idea.CentCom/.idea/workspace.xml
+++ b/.idea/.idea.CentCom/.idea/workspace.xml
@@ -11,22 +11,16 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="28c8f7e3-4e14-4e22-b8f6-ae65cdd7cd09" name="Default Changelist" comment="">
-      <change afterPath="$PROJECT_DIR$/CentCom.Bot/Commands/AboutCommands.cs" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/CentCom.Bot/Commands/SearchCommands.cs" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/CentCom.Bot/Responders/ServerJoinResponder.cs" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/CentCom.Bot/VersionUtility.cs" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/.idea.CentCom/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/.idea.CentCom/.idea/workspace.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/CentCom.API/CentCom.API.csproj" beforeDir="false" afterPath="$PROJECT_DIR$/CentCom.API/CentCom.API.csproj" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/CentCom.API/Controllers/BanController.cs" beforeDir="false" afterPath="$PROJECT_DIR$/CentCom.API/Controllers/BanController.cs" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/CentCom.API/Models/BanData.cs" beforeDir="false" afterPath="$PROJECT_DIR$/CentCom.Common/Models/DTO/BanData.cs" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/CentCom.API/Models/BanViewViewModel.cs" beforeDir="false" afterPath="$PROJECT_DIR$/CentCom.API/Models/BanViewViewModel.cs" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/CentCom.API/Services/IBanService.cs" beforeDir="false" afterPath="$PROJECT_DIR$/CentCom.API/Services/IBanService.cs" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/CentCom.API/Services/Implemented/BanService.cs" beforeDir="false" afterPath="$PROJECT_DIR$/CentCom.API/Services/Implemented/BanService.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/CentCom.API/CentCom.API.xml" beforeDir="false" afterPath="$PROJECT_DIR$/CentCom.API/CentCom.API.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/CentCom.Bot/CentCom.Bot.csproj" beforeDir="false" afterPath="$PROJECT_DIR$/CentCom.Bot/CentCom.Bot.csproj" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/CentCom.Bot/Program.cs" beforeDir="false" afterPath="$PROJECT_DIR$/CentCom.Bot/Program.cs" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/CentCom.Common/CentCom.Common.csproj" beforeDir="false" afterPath="$PROJECT_DIR$/CentCom.Common/CentCom.Common.csproj" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/CentCom.Exporter/CentCom.Exporter.csproj" beforeDir="false" afterPath="$PROJECT_DIR$/CentCom.Exporter/CentCom.Exporter.csproj" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/CentCom.Exporter/Data/Providers/TgBanProvider.cs" beforeDir="false" afterPath="$PROJECT_DIR$/CentCom.Exporter/Data/Providers/TgBanProvider.cs" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/CentCom.Server/CentCom.Server.csproj" beforeDir="false" afterPath="$PROJECT_DIR$/CentCom.Server/CentCom.Server.csproj" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/CentCom.Server/Services/StandardProviderService.cs" beforeDir="false" afterPath="$PROJECT_DIR$/CentCom.Server/Services/StandardProviderService.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/CentCom.Server/appsettings.json" beforeDir="false" afterPath="$PROJECT_DIR$/CentCom.Server/appsettings.json" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -144,7 +138,7 @@
     <property name="nodejs_package_manager_path" value="npm" />
     <property name="vue.rearranger.settings.migration" value="true" />
   </component>
-  <component name="RunManager" selected=".NET Project.CentCom.Bot">
+  <component name="RunManager" selected=".NET Project.CentCom.Server">
     <configuration name="CentCom.Bot" type="DotNetProject" factoryName=".NET Project">
       <option name="EXE_PATH" value="" />
       <option name="PROGRAM_PARAMETERS" value="" />
@@ -264,7 +258,7 @@
       <workItem from="1629478040004" duration="17933000" />
       <workItem from="1629505090375" duration="12956000" />
       <workItem from="1629519384044" duration="15086000" />
-      <workItem from="1629581834573" duration="39807000" />
+      <workItem from="1629581834573" duration="41343000" />
     </task>
     <task id="LOCAL-00001" summary="update bee ban url">
       <created>1628898475361</created>
@@ -326,5 +320,12 @@
     <option name="CLEAR_INITIAL_COMMIT_MESSAGE" value="true" />
     <MESSAGE value="update bee ban url" />
     <option name="LAST_COMMIT_MESSAGE" value="update bee ban url" />
+  </component>
+  <component name="XDebuggerManager">
+    <breakpoint-manager>
+      <default-breakpoints>
+        <breakpoint enabled="true" type="DotNet Exception Breakpoints" />
+      </default-breakpoints>
+    </breakpoint-manager>
   </component>
 </project>

--- a/CentCom.API/CentCom.API.csproj
+++ b/CentCom.API/CentCom.API.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>net5.0</TargetFramework>
-        <Version>1.3.14</Version>
+        <Version>1.3.15</Version>
         <UserSecretsId>1f5f48fa-862f-4472-ba34-2c5a26035e88</UserSecretsId>
     </PropertyGroup>
 

--- a/CentCom.API/CentCom.API.xml
+++ b/CentCom.API/CentCom.API.xml
@@ -6,7 +6,7 @@
     <members>
         <member name="M:CentCom.API.Controllers.BanController.GetBansForKey(System.String,System.Boolean,System.Nullable{System.Int32})">
             <summary>
-                Retrieves stored bans for a provided ckey.
+            Retrieves stored bans for a provided ckey.
             </summary>
             <param name="key">A BYOND key, will be converted into CKey</param>
             <param name="onlyActive">Operator for controlling if only active bans will be returned</param>
@@ -17,130 +17,43 @@
         </member>
         <member name="M:CentCom.API.Controllers.BanController.GetSources">
             <summary>
-                Lists all available ban sources
+            Lists all available ban sources
             </summary>
             <returns>A collection of ban sources</returns>
             <response code="200">The list of ban sources</response>
         </member>
         <member name="M:CentCom.API.Controllers.BanController.GetBan(System.Int32)">
             <summary>
-                Retrieves a specific ban from CentCom using the internal ID
+            Retrieves a specific ban from CentCom using the internal ID
             </summary>
             <param name="id">The CentCom Ban ID of the ban</param>
             <returns>The ban specified</returns>
             <response code="200">The desired ban</response>
             <response code="404">Ban ID was invalid</response>
         </member>
-        <member name="T:CentCom.API.Models.BanData">
-            <summary>
-                DTO for all data that a ban contains
-            </summary>
-        </member>
-        <member name="P:CentCom.API.Models.BanData.ID">
-            <summary>
-                Internal CentCom DB ID
-            </summary>
-        </member>
-        <member name="P:CentCom.API.Models.BanData.SourceID">
-            <summary>
-                Internal CentCom DB ID for the ban source
-            </summary>
-        </member>
-        <member name="P:CentCom.API.Models.BanData.SourceName">
-            <summary>
-                The textual name of the ban source
-            </summary>
-        </member>
-        <member name="P:CentCom.API.Models.BanData.SourceRoleplayLevel">
-            <summary>
-                The roleplay level of the ban source
-            </summary>
-        </member>
-        <member name="P:CentCom.API.Models.BanData.Type">
-            <summary>
-                The type of ban
-            </summary>
-        </member>
-        <member name="P:CentCom.API.Models.BanData.CKey">
-            <summary>
-                The CKey of the banned user
-            </summary>
-        </member>
-        <member name="P:CentCom.API.Models.BanData.BannedOn">
-            <summary>
-                The DateTime at which the user was banned
-            </summary>
-        </member>
-        <member name="P:CentCom.API.Models.BanData.BannedBy">
-            <summary>
-                The user who created the ban
-            </summary>
-        </member>
-        <member name="P:CentCom.API.Models.BanData.Reason">
-            <summary>
-                The reason for the ban
-            </summary>
-        </member>
-        <member name="P:CentCom.API.Models.BanData.Expires">
-            <summary>
-                The expiration, if present, of the ban
-            </summary>
-        </member>
-        <member name="P:CentCom.API.Models.BanData.UnbannedBy">
-            <summary>
-                The user, if present, who removed the ban
-            </summary>
-        </member>
-        <member name="P:CentCom.API.Models.BanData.BanID">
-            <summary>
-                The ban ID, if present, as provided by the source
-            </summary>
-        </member>
-        <member name="P:CentCom.API.Models.BanData.Jobs">
-            <summary>
-                The jobs, if present, that the user is banned from
-            </summary>
-        </member>
-        <member name="P:CentCom.API.Models.BanData.BanAttributes">
-            <summary>
-                Any additional attributes added to this ban by CentCom
-            </summary>
-        </member>
-        <member name="P:CentCom.API.Models.BanData.Active">
-            <summary>
-                If the ban is currently active, as predicted by CentCom
-            </summary>
-        </member>
-        <member name="M:CentCom.API.Models.BanData.FromBan(CentCom.Common.Models.Ban)">
-            <summary>
-                Generates a BanData DTO from a database Ban.
-            </summary>
-            <param name="ban">The object to copy data from</param>
-            <returns>A BanData DTO</returns>
-        </member>
         <member name="T:CentCom.API.Models.BanSourceData">
             <summary>
-                DTO for ban sources
+            DTO for ban sources
             </summary>
         </member>
         <member name="P:CentCom.API.Models.BanSourceData.ID">
             <summary>
-                Internal CentCom DB ID
+            Internal CentCom DB ID
             </summary>
         </member>
         <member name="P:CentCom.API.Models.BanSourceData.Name">
             <summary>
-                Display name
+            Display name
             </summary>
         </member>
         <member name="P:CentCom.API.Models.BanSourceData.RoleplayLevel">
             <summary>
-                The roleplay level of this ban source
+            The roleplay level of this ban source
             </summary>
         </member>
         <member name="M:CentCom.API.Models.BanSourceData.FromBanSource(CentCom.Common.Models.BanSource)">
             <summary>
-                Generates a DTO from a database BanSource
+            Generates a DTO from a database BanSource
             </summary>
             <param name="source">The object to copy data from</param>
             <returns>A BanSource DTO</returns>

--- a/CentCom.Bot/CentCom.Bot.csproj
+++ b/CentCom.Bot/CentCom.Bot.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <Version>1.3.14</Version>
+        <Version>1.3.15</Version>
         <TargetFramework>net5.0</TargetFramework>
         <UserSecretsId>c8af1449-8cdf-4707-a66d-51e896551bfb</UserSecretsId>
     </PropertyGroup>

--- a/CentCom.Common/CentCom.Common.csproj
+++ b/CentCom.Common/CentCom.Common.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>net5.0</TargetFramework>
-        <Version>1.3.14</Version>
+        <Version>1.3.15</Version>
     </PropertyGroup>
 
     <ItemGroup>

--- a/CentCom.Exporter/CentCom.Exporter.csproj
+++ b/CentCom.Exporter/CentCom.Exporter.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>net5.0</TargetFramework>
-        <Version>1.3.14</Version>
+        <Version>1.3.15</Version>
         <UserSecretsId>a625260b-31a1-4f4b-84f4-96ccc7a335e7</UserSecretsId>
     </PropertyGroup>
 

--- a/CentCom.Exporter/Data/Providers/TgBanProvider.cs
+++ b/CentCom.Exporter/Data/Providers/TgBanProvider.cs
@@ -74,7 +74,8 @@ namespace CentCom.Exporter.Data.Providers
 				FROM
 					ban b
 				WHERE
-					(@cursor IS NULL OR b.id < @cursor)
+                    b.ckey IS NOT NULL
+					AND (@cursor IS NULL OR b.id < @cursor)
 					AND (@afterDate IS NULL OR b.bantime > @afterDate)
 					AND (@afterId IS NULL OR b.id > @afterId)
 					AND (@includeJobBans OR b.role = 'Server')

--- a/CentCom.Exporter/Data/Providers/TgBanProvider.cs
+++ b/CentCom.Exporter/Data/Providers/TgBanProvider.cs
@@ -74,7 +74,7 @@ namespace CentCom.Exporter.Data.Providers
 				FROM
 					ban b
 				WHERE
-                    b.ckey IS NOT NULL
+					b.ckey IS NOT NULL
 					AND (@cursor IS NULL OR b.id < @cursor)
 					AND (@afterDate IS NULL OR b.bantime > @afterDate)
 					AND (@afterId IS NULL OR b.id > @afterId)

--- a/CentCom.Server/CentCom.Server.csproj
+++ b/CentCom.Server/CentCom.Server.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFramework>net5.0</TargetFramework>
-        <Version>1.3.14</Version>
+        <Version>1.3.15</Version>
         <UserSecretsId>94572412-7eb8-4652-aff2-8afc154cf139</UserSecretsId>
     </PropertyGroup>
 

--- a/CentCom.Server/Services/StandardProviderService.cs
+++ b/CentCom.Server/Services/StandardProviderService.cs
@@ -45,7 +45,7 @@ namespace CentCom.Server.Services
                 BannedBy = x.BannedBy?.CanonicalKey,
                 BannedOn = x.BannedOn.DateTime,
                 BanType = x.BanType,
-                CKey = x.CKey.CanonicalKey,
+                CKey = x.CKey?.CanonicalKey,
                 Expires = x.Expires?.DateTime,
                 UnbannedBy = x.UnbannedBy?.CanonicalKey,
                 Reason = x.Reason,

--- a/CentCom.Server/appsettings.json
+++ b/CentCom.Server/appsettings.json
@@ -12,6 +12,12 @@
       "display": "Shiptest 13",
       "roleplayLevel": "Medium",
       "url": "https://bans.shiptest.ga/"
+    },
+    {
+      "id": "austation",
+      "display": "AuStation",
+      "roleplayLevel": "Low",
+      "url": "https://api.austation.net/"
     }
   ]
 }


### PR DESCRIPTION
Changelog:
- Added AuStation as a standard source
- Resolved bug wherein a standard source would fail if a provided ckey was null.
- Excluded null ckey bans (typically IP bans) from exporter-exposed bans