### PR TITLE
Updates sources to show Beestation servers as "Beestation" and "Beestation LRP"

### DIFF
--- a/CentCom.Server/BanSources/BeeBanParser.cs
+++ b/CentCom.Server/BanSources/BeeBanParser.cs
@@ -21,16 +21,28 @@ public class BeeBanParser : BanParser
 
     protected override Dictionary<string, BanSource> Sources => new Dictionary<string, BanSource>
     {
+        { "bee-acacia", new BanSource
+        {
+            Display = "Beestation Acacia",
+            Name = "bee-acacia",
+            RoleplayLevel = RoleplayLevel.Medium
+        } },
+        { "bee-sage", new BanSource
+        {
+            Display = "Beestation Sage",
+            Name = "bee-sage",
+            RoleplayLevel = RoleplayLevel.Medium
+        } },
         { "bee-lrp", new BanSource
         {
-            Display = "Beestation LRP",
+            Display = "Beestation Golden",
             Name = "bee-lrp",
             RoleplayLevel = RoleplayLevel.Low
         } },
-        { "bee-mrp", new BanSource
+        { "bee-linden", new BanSource
         {
-            Display = "Beestation MRP",
-            Name = "bee-mrp",
+            Display = "Beestation Linden",
+            Name = "bee-linden",
             RoleplayLevel = RoleplayLevel.Medium
         } }
     };

--- a/CentCom.Server/BanSources/BeeBanParser.cs
+++ b/CentCom.Server/BanSources/BeeBanParser.cs
@@ -21,29 +21,17 @@ public class BeeBanParser : BanParser
 
     protected override Dictionary<string, BanSource> Sources => new Dictionary<string, BanSource>
     {
-        { "bee-acacia", new BanSource
+        { "bee-mrp", new BanSource
         {
-            Display = "Beestation Acacia",
-            Name = "bee-acacia",
-            RoleplayLevel = RoleplayLevel.Medium
-        } },
-        { "bee-sage", new BanSource
-        {
-            Display = "Beestation Sage",
-            Name = "bee-sage",
+            Display = "Beestation",
+            Name = "bee-mrp",
             RoleplayLevel = RoleplayLevel.Medium
         } },
         { "bee-lrp", new BanSource
         {
-            Display = "Beestation Golden",
+            Display = "Beestation LRP",
             Name = "bee-lrp",
             RoleplayLevel = RoleplayLevel.Low
-        } },
-        { "bee-linden", new BanSource
-        {
-            Display = "Beestation Linden",
-            Name = "bee-linden",
-            RoleplayLevel = RoleplayLevel.Medium
         } }
     };
 

--- a/CentCom.Server/Services/BeeBanService.cs
+++ b/CentCom.Server/Services/BeeBanService.cs
@@ -16,10 +16,8 @@ namespace CentCom.Server.Services;
 public class BeeBanService : RestBanService
 {
     private const int ParallelRequests = 1;
-    private static readonly BanSource AcaciaSource = new BanSource { Name = "bee-acacia" };
-    private static readonly BanSource SageSource = new BanSource { Name = "bee-sage" };
+    private static readonly BanSource MrpSource = new BanSource { Name = "bee-mrp" };
     private static readonly BanSource LrpSource = new BanSource { Name = "bee-lrp" };
-    private static readonly BanSource LindenSource = new BanSource { Name = "bee-linden" };
 
     public BeeBanService(ILogger<BeeBanService> logger) : base(logger)
     {
@@ -109,9 +107,9 @@ public class BeeBanService : RestBanService
         return (raw.ToLower()) switch
         {
             "bs_golden" => LrpSource,
-            "bs_sage" => SageSource,
-            "bs_acacia" => AcaciaSource,
-            "bs_linden" => LindenSource,
+            "bs_sage" => MrpSource,
+            "bs_acacia" => MrpSource,
+            "bs_linden" => MrpSource,
             _ => throw new Exception(
                 $"Failed to convert raw value of Beestation ban source to BanSource: \"{raw}\""),
         };

--- a/CentCom.Server/Services/BeeBanService.cs
+++ b/CentCom.Server/Services/BeeBanService.cs
@@ -16,8 +16,10 @@ namespace CentCom.Server.Services;
 public class BeeBanService : RestBanService
 {
     private const int ParallelRequests = 1;
+    private static readonly BanSource AcaciaSource = new BanSource { Name = "bee-acacia" };
+    private static readonly BanSource SageSource = new BanSource { Name = "bee-sage" };
     private static readonly BanSource LrpSource = new BanSource { Name = "bee-lrp" };
-    private static readonly BanSource MrpSource = new BanSource { Name = "bee-mrp" };
+    private static readonly BanSource LindenSource = new BanSource { Name = "bee-linden" };
 
     public BeeBanService(ILogger<BeeBanService> logger) : base(logger)
     {
@@ -107,9 +109,9 @@ public class BeeBanService : RestBanService
         return (raw.ToLower()) switch
         {
             "bs_golden" => LrpSource,
-            "bs_sage" => MrpSource,
-            "bs_acacia" => MrpSource,
-            "bs_linden" => MrpSource,
+            "bs_sage" => SageSource,
+            "bs_acacia" => AcaciaSource,
+            "bs_linden" => LindenSource,
             _ => throw new Exception(
                 $"Failed to convert raw value of Beestation ban source to BanSource: \"{raw}\""),
         };


### PR DESCRIPTION
Updates the ban sources and names for Beestation CC bans

- General Beestation servers are set to "Beestation", and are set to Medium RP
- Golden doesnt exist anymore, but is left as "Beestation LRP" ~~for when its re-opened~~ for redundancy purposes.
