### PR TITLE
Resolve issue with ban exporter bans not deserializing correctly

### DIFF
--- a/CentCom.API/CentCom.API.csproj
+++ b/CentCom.API/CentCom.API.csproj
@@ -7,8 +7,6 @@
 
     <ItemGroup>
         <PackageReference Include="BuildBundlerMinifier" Version="3.2.449" />
-        <PackageReference Include="Enums.NET" Version="4.0.1" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="7.0.8" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="7.0.8" />
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.8" />
         <PackageReference Include="MinVer" Version="4.3.0">

--- a/CentCom.API/CentCom.API.xml
+++ b/CentCom.API/CentCom.API.xml
@@ -44,6 +44,7 @@
             </summary>
             <param name="Version">The version of the application in semver</param>
             <param name="Commit">The commit hash of the build that the application is running</param>
+            <param name="CopyrightNotice">The copyright notice for this version of the application</param>
         </member>
         <member name="M:CentCom.API.Models.AppVersionDTO.#ctor(System.String,System.String,System.String)">
             <summary>
@@ -51,12 +52,16 @@
             </summary>
             <param name="Version">The version of the application in semver</param>
             <param name="Commit">The commit hash of the build that the application is running</param>
+            <param name="CopyrightNotice">The copyright notice for this version of the application</param>
         </member>
         <member name="P:CentCom.API.Models.AppVersionDTO.Version">
             <summary>The version of the application in semver</summary>
         </member>
         <member name="P:CentCom.API.Models.AppVersionDTO.Commit">
             <summary>The commit hash of the build that the application is running</summary>
+        </member>
+        <member name="P:CentCom.API.Models.AppVersionDTO.CopyrightNotice">
+            <summary>The copyright notice for this version of the application</summary>
         </member>
         <member name="T:CentCom.API.Models.BanSourceData">
             <summary>

--- a/CentCom.API/Models/AppVersionDTO.cs
+++ b/CentCom.API/Models/AppVersionDTO.cs
@@ -7,6 +7,7 @@ namespace CentCom.API.Models;
 /// </summary>
 /// <param name="Version">The version of the application in semver</param>
 /// <param name="Commit">The commit hash of the build that the application is running</param>
+/// <param name="CopyrightNotice">The copyright notice for this version of the application</param>
 public record AppVersionDTO(string Version, string Commit, string CopyrightNotice)
 {
     internal AppVersionDTO(AssemblyInformation assemblyInfo) : this(assemblyInfo.Version, assemblyInfo.Commit,

--- a/CentCom.Common/CentCom.Common.csproj
+++ b/CentCom.Common/CentCom.Common.csproj
@@ -12,7 +12,6 @@
         <PackageReference Include="Npgsql" Version="7.0.4" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.4" />
         <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="7.0.0" />
-        <PackageReference Include="Quartz" Version="3.6.3" />
         <PackageReference Include="Remora.Rest" Version="3.2.0" />
     </ItemGroup>
 

--- a/CentCom.Common/Models/Rest/RestBan.cs
+++ b/CentCom.Common/Models/Rest/RestBan.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 using CentCom.Common.Abstract;
 
 namespace CentCom.Common.Models.Rest;
@@ -15,5 +16,6 @@ public record RestBan
     DateTimeOffset? Expires,
     ICKey UnbannedBy,
     IReadOnlyList<IRestJobBan> JobBans,
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     int? RoundId
 ) : IRestBan;

--- a/CentCom.Server/Services/StandardProviderService.cs
+++ b/CentCom.Server/Services/StandardProviderService.cs
@@ -5,13 +5,11 @@ using System.Net;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
-using CentCom.Common.Abstract;
 using CentCom.Common.Extensions;
 using CentCom.Common.Models;
 using CentCom.Common.Models.Rest;
 using CentCom.Server.Configuration;
 using Microsoft.Extensions.Logging;
-using Remora.Rest.Extensions;
 using RestSharp;
 using RestSharp.Serializers.Json;
 
@@ -34,7 +32,7 @@ public class StandardProviderService : RestBanService
         var request = new RestRequest("api/ban");
         if (cursor.HasValue)
             request.AddQueryParameter("cursor", cursor.ToString());
-        var response = await Client.ExecuteAsync<IEnumerable<IRestBan>>(request);
+        var response = await Client.ExecuteAsync<IEnumerable<RestBan>>(request);
 
         if (response.StatusCode != HttpStatusCode.OK)
             FailedRequest(response);
@@ -92,7 +90,6 @@ public class StandardProviderService : RestBanService
         // Setup JSON for client
         var options = new JsonSerializerOptions();
         options.AddCentComOptions();
-        options.AddDataObjectConverter<IRestBan, RestBan>();
         options.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
         options.Converters.Insert(0, new JsonStringEnumConverter());
         

--- a/CentCom.Test/CentCom.Test.csproj
+++ b/CentCom.Test/CentCom.Test.csproj
@@ -23,7 +23,6 @@
 
     <ItemGroup>
         <ProjectReference Include="..\CentCom.Common\CentCom.Common.csproj" />
-        <ProjectReference Include="..\CentCom.Exporter\CentCom.Exporter.csproj" />
         <ProjectReference Include="..\CentCom.Server\CentCom.Server.csproj" />
     </ItemGroup>
 


### PR DESCRIPTION
Changelog:
- Fix IRestBan not serializing properly due to new Remora.Rest behavior; deserializing as RestBan now which I think is fine
- Remove 5 unused references throughout the project