### PR TITLE
Patch for mutable data not being correctly updated

### DIFF
--- a/CentCom.Server/BanSources/BanParser.cs
+++ b/CentCom.Server/BanSources/BanParser.cs
@@ -231,14 +231,20 @@ public abstract class BanParser : IJob
             {
                 var changed = false;
 
-                // Check for a difference in date time, unbans, or reason
-                if (matchedBan.Reason != b.Reason || matchedBan.BannedOn != b.BannedOn || matchedBan.Expires != b.Expires ||
-                    matchedBan.UnbannedBy != b.UnbannedBy)
+                // Check for changes in mutable data
+                if (matchedBan.Reason != b.Reason 
+                    || matchedBan.BannedOn != b.BannedOn 
+                    || matchedBan.Expires != b.Expires 
+                    || matchedBan.UnbannedBy != b.UnbannedBy
+                    || matchedBan.BannedBy != b.BannedBy
+                    || matchedBan.CKey != b.CKey)
                 {
                     matchedBan.Reason = b.Reason;
                     matchedBan.BannedOn = b.BannedOn;
                     matchedBan.Expires = b.Expires;
                     matchedBan.UnbannedBy = b.UnbannedBy;
+                    matchedBan.BannedBy = b.BannedBy;
+                    matchedBan.CKey = b.CKey;
                     changed = true;
                 }
 


### PR DESCRIPTION
Reported by ShipTest, looks like some mutable data isn't being updated and as a result bad data from origin can persist when origin IDs are used.