### PR TITLE
Make active parsers configurable

### DIFF
--- a/CentCom.Server/BanSources/VgBanParser.cs
+++ b/CentCom.Server/BanSources/VgBanParser.cs
@@ -7,15 +7,9 @@ using Microsoft.Extensions.Logging;
 
 namespace CentCom.Server.BanSources;
 
-public class VgBanParser : BanParser
+public class VgBanParser(DatabaseContext dbContext, VgBanService banService, ILogger<VgBanParser> logger)
+    : BanParser(dbContext, logger)
 {
-    private readonly VgBanService _banService;
-
-    public VgBanParser(DatabaseContext dbContext, VgBanService banService, ILogger<VgBanParser> logger) : base(dbContext, logger)
-    {
-        _banService = banService;
-    }
-
     protected override Dictionary<string, BanSource> Sources => new()
     {
         { "vgstation", new BanSource
@@ -32,13 +26,13 @@ public class VgBanParser : BanParser
     public override async Task<List<Ban>> FetchAllBansAsync()
     {
         Logger.LogInformation("Fetching all bans for /vg/station...");
-        return await _banService.GetBansAsync();
+        return await banService.GetBansAsync();
     }
 
     public override async Task<List<Ban>> FetchNewBansAsync()
     {
         // Note that the /vg/station website only has a single page for bans, so we always do a full refresh
         Logger.LogInformation("Fetching new bans for /vg/station...");
-        return await _banService.GetBansAsync();
+        return await banService.GetBansAsync();
     }
 }

--- a/CentCom.Server/Program.cs
+++ b/CentCom.Server/Program.cs
@@ -15,6 +15,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Quartz;
 using Serilog;
+using Serilog.Filters;
 
 namespace CentCom.Server;
 
@@ -27,7 +28,7 @@ internal class Program
             .Enrich.FromLogContext()
             .WriteTo.Logger(lc =>
             {
-                //lc.Filter.ByExcluding(Matching.FromSource("Quartz"));
+                lc.Filter.ByExcluding(Matching.FromSource("Quartz"));
                 lc.WriteTo.Console(
                     outputTemplate:
                     "[{Timestamp:HH:mm:ss} {Level:u3}] ({SourceContext}) {Message:lj}{NewLine}{Exception}");
@@ -43,7 +44,7 @@ internal class Program
         Log.Logger.ForContext<Program>()
             .Information("Starting CentCom Server {Version} ({Commit})", AssemblyInformation.Current.Version,
                 AssemblyInformation.Current.Commit[..7]);
-        
+
         return CreateHostBuilder(args).RunConsoleAsync();
     }
 

--- a/CentCom.Server/appsettings.json
+++ b/CentCom.Server/appsettings.json
@@ -6,18 +6,11 @@
   "sourceConfig": {
     "allowFulpExpiredSSL": true
   },
-  "standardSources": [
-    {
-      "id": "shiptest",
-      "display": "Shiptest 13",
-      "roleplayLevel": "Medium",
-      "url": "https://bans.shiptest.ga/"
-    },
-    {
-      "id": "austation",
-      "display": "AuStation",
-      "roleplayLevel": "Low",
-      "url": "https://api.austation.net/"
-    }
+  "standardSources": [],
+  "enabledParsers": [
+    "BeeBanParser",
+    "FulpBanParser",
+    "TgBanParser",
+    "YogBanParser"
   ]
 }


### PR DESCRIPTION
Add configurability to which parsers are actively run. I noticed that several sources are no longer active or are blocking requests so I'd rather just prevent the requests to them (for now) but keep the parser in case things change.